### PR TITLE
Configure IMA policy on monitored nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+inventory.yml

--- a/README.md
+++ b/README.md
@@ -163,24 +163,16 @@ monitored nodes are connected.
 
 ### DNS
 
-A `systemd-resolved` configuration snippet is added to forward the hostname
+A `systemd-resolved` configuration is added to forward the hostname
 resolution for the `*.demo` domain to the `libvirt` `dnsmasq` instance created
 to handle the virtual NAT network.
 
-The following snippet is placed in
-`/etc/systemd/resolved.conf.d/resolved-demo.conf`:
-
+This is done by running the following commands
 ```
-[Resolve]
-DNS=192.168.42.1
-Domains=~demo
+resolvectl dns virbr-demo 192.168.42.1
+resolvectl domain virbr-demo ~demo
 ```
 
-This is done to allow the monitored nodes to be addressed by their hostname
-(e.g. `node1.demo`)
-
-This change is permanent. To undo, remove the snippet by running:
-
-```
-sudo rm /etc/systemd/resolved.conf.d/resolved-demo.conf
-```
+This change is not permanent and is lost upon reboot. It is necessary to re-run
+the playbook to restore this configuration allowing the monitored nodes
+hostnames to be resolved by `libvirt` `dnsmasq` instance

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ By default, a virtual interface called `virbr-demo` is created. This interface
 is destroyed on reboot or if the `virsh net-destroy --network demo` command is
 executed.
 
+#### Enabling the bridge network in qemu
+
+To allow the created virtual network to be used by qemu, the file
+`/etc/qemu/bridge.conf` is modified to include the newly created bridge.
+
+This change is persistent.
+
+To revert it, remove the line `allow virbr-demo` from the
+`/etc/qemu/bridge.conf` file.
+
 ### Firewall
 
 We run the Keylime verifier and registrar services as containers on the host

--- a/demo.yml
+++ b/demo.yml
@@ -19,6 +19,22 @@
         state: directory
         mode: '0755'
 
+    - name: Generate CA and IMA signing key certificates
+      vars:
+        base_dir: "{{ demo_dir }}/certs"
+        ca_dir: "{{ base_dir }}/CA"
+        root_ca_dir: "{{ ca_dir }}/root"
+        ima_dir: "{{ demo_dir }}/ima"
+      include_role:
+        name: generate_certs
+
+    - name: Generate signed IMA policy
+      vars:
+        ima_key: "{{ demo_dir }}/ima/private.key"
+        signed_policy: "{{ demo_dir }}/ima/signed_ima_policy"
+      include_role:
+        name: sign_ima_policy
+
     - name: Create the VMs if they are not created yet
       vars:
         network:
@@ -81,3 +97,12 @@
     - name: Install and configure keylime agent in the monitored nodes
       include_role:
         name: install_keylime_agent
+
+    - name: Setup IMA policy and Kernel arguments
+      vars:
+        controller_root_ca_cert: "{{ hostvars['controller'].demo_dir}}/ima/ca.crt"
+        controller_ima_cert: "{{ hostvars['controller'].demo_dir}}/ima/ima.crt"
+        controller_ima_policy: "{{ hostvars['controller'].demo_dir }}/ima/signed_ima_policy"
+        ima_cert_dir: "/root/ima/certs"
+      include_role:
+        name: ima_setup

--- a/roles/configure_network/tasks/main.yml
+++ b/roles/configure_network/tasks/main.yml
@@ -33,6 +33,16 @@
     state: active
     name: "{{ network.name }}"
 
+- name: Enable the virtual network to be used by qemu
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/qemu/bridge.conf
+    line: "allow virbr-demo"
+    create: yes
+    state: present
+    insertafter: EOF
+    backup: yes
+
 - name: Create directory if not present
   become: true
   ansible.builtin.file:

--- a/roles/configure_network/tasks/main.yml
+++ b/roles/configure_network/tasks/main.yml
@@ -33,6 +33,15 @@
     state: active
     name: "{{ network.name }}"
 
+- name: Create directory if not present
+  become: true
+  ansible.builtin.file:
+    path: "/etc/systemd/resolved.conf.d"
+    state: directory
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Configure controller systemd-resolved for hostname resolution (DNS)
   become: true
   ansible.builtin.template:

--- a/roles/configure_network/tasks/main.yml
+++ b/roles/configure_network/tasks/main.yml
@@ -54,9 +54,9 @@
 
 - name: Configure controller systemd-resolved for hostname resolution (DNS)
   become: true
-  ansible.builtin.template:
-    src: "resolved-demo.conf.j2"
-    dest: "/etc/systemd/resolved.conf.d/resolved-demo.conf"
+  ansible.builtin.shell:
+    resolvectl dns virbr-demo 192.168.42.1 &&
+    resolvectl domain virbr-demo ~demo
 
 - name: Restart systemd-resolved to update DNS resolution
   become: true

--- a/roles/configure_network/templates/resolved-demo.conf.j2
+++ b/roles/configure_network/templates/resolved-demo.conf.j2
@@ -1,3 +1,0 @@
-[Resolve]
-DNS={{ network.dhcp_ip }}
-Domains=~{{ network.domain }}

--- a/roles/create_vms/files/create_vm.sh
+++ b/roles/create_vms/files/create_vm.sh
@@ -153,10 +153,10 @@ if [[ ! -d "${OUT_DIR}" ]]; then
     exit 1
 fi
 
-CRYPT_PW=$(python -c "import crypt;print(crypt.crypt('${PASSWORD}'));")
+CRYPT_PW=$(mkpasswd -m sha-512 ${PASSWORD})
 debug "CRYPT_PW = ${CRYPT_PW}"
 
-CRYPT_ROOT_PW=$(python -c "import crypt;print(crypt.crypt('${ROOT_PASSWORD}'));")
+CRYPT_ROOT_PW=$(mkpasswd -m sha-512 ${ROOT_PASSWORD})
 debug "CRYPT_ROOT_PW = ${CRYPT_ROOT_PW}"
 
 if [[ "${IP}" != "dhcp" ]]; then

--- a/roles/create_vms/files/create_vm.sh
+++ b/roles/create_vms/files/create_vm.sh
@@ -273,4 +273,4 @@ virt-install --connect qemu:///session \
     --tpm backend.type=emulator,backend.version=2.0,model=tpm-tis \
     --console pty,target_type=serial \
     --network bridge=${NETWORK_BRIDGE} \
-    --boot uefi
+    --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no

--- a/roles/dependencies/vars/main.yml
+++ b/roles/dependencies/vars/main.yml
@@ -12,3 +12,4 @@ dependencies:
   - swtpm
   - swtpm-tools
   - tpm2-tools
+  - virt-install

--- a/roles/dependencies/vars/main.yml
+++ b/roles/dependencies/vars/main.yml
@@ -3,12 +3,14 @@
 dependencies:
   - curl
   - firewalld
+  - ima-evm-utils
   - jq
   - libvirt
   - openssl
   - podman
   - python3
   - python3-cryptography
+  - rpm-plugin-ima
   - swtpm
   - swtpm-tools
   - tpm2-tools

--- a/roles/generate_certs/tasks/main.yml
+++ b/roles/generate_certs/tasks/main.yml
@@ -1,0 +1,100 @@
+---
+- name: Ensure necessary directories exist
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0700'
+  loop:
+    - "{{ root_ca_dir }}"
+    - "{{ ima_dir }}"
+
+- name: Generate Root CA private key
+  community.crypto.openssl_privatekey:
+    path: "{{ root_ca_dir }}/private.key"
+    size: 4096
+
+- name: Generate Root CA CSR
+  community.crypto.openssl_csr_pipe:
+    privatekey_path: "{{ root_ca_dir }}/private.key"
+    subject:
+      CN: RootCA
+      O: ExampleCorp
+      C: US
+    basic_constraints:
+      - "CA:TRUE"
+    key_usage:
+      - "digitalSignature"
+      - "cRLSign"
+      - "keyCertSign"
+    basic_constraints_critical: true
+    key_usage_critical: true
+  register: root_csr
+
+- name: Self-sign Root CA certificate
+  community.crypto.x509_certificate:
+    csr_content: "{{ root_csr.csr }}"
+    path: "{{ root_ca_dir }}/ca.crt"
+    privatekey_path: "{{ root_ca_dir }}/private.key"
+    provider: selfsigned
+    selfsigned_create_subject_key_identifier: "create_if_not_provided"
+
+- name: Generate IMA CA private key
+  community.crypto.openssl_privatekey:
+    path: "{{ ima_dir }}/ca.key"
+    size: 4096
+
+- name: Generate IMA CA CSR
+  community.crypto.openssl_csr_pipe:
+    privatekey_path: "{{ ima_dir }}/ca.key"
+    subject:
+      CN: Custom IMA CA
+      O: ExampleCorp
+      C: US
+    basic_constraints:
+      - "CA:TRUE"
+    key_usage:
+      - "keyCertSign"
+    basic_constraints_critical: true
+    key_usage_critical: true
+  register: ima_ca_csr
+
+- name: Self-sign IMA CA certificate
+  community.crypto.x509_certificate:
+    csr_content: "{{ ima_ca_csr.csr }}"
+    path: "{{ ima_dir }}/ca.crt"
+    privatekey_path: "{{ ima_dir }}/ca.key"
+    provider: selfsigned
+    selfsigned_create_subject_key_identifier: "create_if_not_provided"
+
+- name: Generate IMA signing key
+  community.crypto.openssl_privatekey:
+    path: "{{ ima_dir }}/private.key"
+    size: 3072
+
+- name: Generate IMA signing key CSR
+  community.crypto.openssl_csr:
+    path: "{{ ima_dir }}/ima.csr"
+    privatekey_path: "{{ ima_dir }}/private.key"
+    subject:
+      CN: IMA signing
+      O: ExampleCorp
+      C: US
+    basic_constraints:
+      - "CA:FALSE"
+    extended_key_usage:
+      - "codeSigning"
+    key_usage:
+      - "digitalSignature"
+      - "nonRepudiation"
+    basic_constraints_critical: true
+    key_usage_critical: true
+
+- name: Sign IMA signing key certificate with IMA CA
+  community.crypto.x509_certificate:
+    path: "{{ ima_dir }}/ima.crt"
+    csr_path: "{{ ima_dir }}/ima.csr"
+    provider: ownca
+    ownca_privatekey_path: "{{ ima_dir }}/ca.key"
+    ownca_path: "{{ ima_dir }}/ca.crt"
+    ownca_create_authority_key_identifier: true
+    ownca_create_subject_key_identifier: "create_if_not_provided"

--- a/roles/ima_setup/tasks/main.yml
+++ b/roles/ima_setup/tasks/main.yml
@@ -1,0 +1,131 @@
+---
+- name: Make sure dependencies are installed and up-to-date
+  become: true
+  ansible.builtin.dnf:
+    name: "{{ item }}"
+    state: latest
+  loop:
+    - "ima-evm-utils"
+    - "mokutil"
+
+- name: Create IMA configuration directory if not present
+  become: true
+  ansible.builtin.file:
+    path: "/etc/ima"
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: '0644'
+
+- name: Ensure IMA certificate directory exist
+  ansible.builtin.file:
+    path: "{{ ima_cert_dir }}"
+    state: directory
+    mode: '0700'
+
+- name: Read Root CA certificate from controller
+  slurp:
+    path: "{{ controller_root_ca_cert }}"
+  delegate_to: controller
+  run_once: true
+  register: ca_cert
+
+- name: Write Root CA certificate file
+  copy:
+    dest: "{{ ima_cert_dir }}/ca.crt"
+    content: "{{ (ca_cert.content | b64decode) }}"
+
+- name: Read IMA certificate from controller
+  slurp:
+    path: "{{ controller_ima_cert }}"
+  delegate_to: controller
+  run_once: true
+  register: ima_cert
+
+- name: Write IMA certificate file
+  copy:
+    dest: "{{ ima_cert_dir }}/ima.crt"
+    content: "{{ (ima_cert.content | b64decode) }}"
+
+- name: Convert IMA PEM X.509 certificate to DER format
+  community.crypto.x509_certificate_convert:
+    src_path: "{{ ima_cert_dir }}/ima.crt"
+    dest_path: "{{ ima_cert_dir }}/ima.der"
+    format: der
+  run_once: true
+
+- name: Ensure IMA keys directory exist
+  become: true
+  ansible.builtin.file:
+    path: "/etc/keys/ima"
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: '0644'
+
+- name: Read IMA certificate in DER format to be used for Secure Boot
+  slurp:
+    path: "{{ ima_cert_dir }}/ima.der"
+  run_once: true
+  register: ima_cert_der
+
+- name: Write IMA certificate to be used for Secure Boot
+  become: true
+  copy:
+    content: "{{ (ima_cert_der.content | b64decode) }}"
+    dest: "/etc/keys/ima/ima.der"
+
+- name: Get IMA keyring ID
+  become: true
+  ansible.builtin.shell:
+    keyctl show %keyring:.ima | grep -o -m 1 '^ [0-9]\+'
+  register: keyring_id
+
+#- name: Install key to IMA keyring
+#  become: true
+#  ansible.builtin.shell:
+#    evmctl import /etc/keys/ima/ima.der .ima
+#
+#- name: Check that key was correctly imported to ima keyring
+#  become: true
+#  ansible.builtin.shell:
+#    keyctl show %keyring:.ima
+
+- name: Read signed IMA policy from controller
+  slurp:
+    path: "{{ controller_ima_policy }}"
+  delegate_to: controller
+  run_once: true
+  register: ima_policy
+
+- name: Write signed IMA policy
+  become: true
+  copy:
+    dest: "/etc/ima/ima-policy"
+    content: "{{ (ima_policy.content | b64decode) }}"
+    owner: "root"
+    group: "root"
+    mode: '0644'
+
+- name: Check attributes of signed policy
+  become: true
+  ansible.builtin.shell:
+    getfattr -m . -d /etc/ima/ima-policy
+
+- name: Re-generate initramfs to incorporate the IMA signing public key
+  become: true
+  ansible.builtin.shell:
+    dracut --kver $(uname -r) --force --add integrity
+
+- name: Set IMA argument in Kernel command line if not present
+  become: true
+  ansible.builtin.shell: >
+    grubby --update-kernel DEFAULT --args 'ima_appraise=fix ima_canonical_fmt ima_policy=tcb ima_template=ima-sig'
+
+- name: Reboot the machine
+  ansible.builtin.reboot:
+
+#- name: Check if the command line is the expected
+#  become: true
+#  ansible.builtin.shell:
+#    grubby --info DEFAULT | grep '^args.*ima_appraise=fix ima_cannonical_fmt ima_policy=tcb ima_template=ima-sig'

--- a/roles/sign_ima_policy/files/ima-policy-simple
+++ b/roles/sign_ima_policy/files/ima-policy-simple
@@ -1,0 +1,17 @@
+# PROC_SUPER_MAGIC
+dont_measure fsmagic=0x9fa0
+# SYSFS_MAGIC
+dont_measure fsmagic=0x62656572
+# DEBUGFS_MAGIC
+dont_measure fsmagic=0x64626720
+# TMPFS_MAGIC
+dont_measure fsmagic=0x01021994
+# RAMFS_MAGIC
+dont_measure fsmagic=0x858458f6
+# SECURITYFS_MAGIC
+dont_measure fsmagic=0x73636673
+# MEASUREMENTS
+measure func=BPRM_CHECK
+measure func=FILE_MMAP mask=MAY_EXEC
+measure func=MODULE_CHECK uid=0
+appraise func=BPRM_CHECK fowner=0 appraise_type=imasig

--- a/roles/sign_ima_policy/tasks/main.yml
+++ b/roles/sign_ima_policy/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Copy the unsigned IMA policy to output location
+  ansible.builtin.copy:
+    src: "ima-policy-simple"
+    dest: "{{ signed_policy }}"
+
+- name: Sign IMA policy using IMA signing key
+  become: true
+  ansible.builtin.shell:
+    evmctl ima_sign --hashalgo sha256 --key "{{ ima_key }}" "{{ signed_policy }}"


### PR DESCRIPTION
 - Creates `/etc/systemd/resolved.conf.d` directory if not present
 - Replaces deprecated python crypt with `mkpasswd` command
 - Add missing dependency `virt-install`
 - Simplify DNS configuration to temporarily change DNS routing
 - Disable Secure Boot to allow IMA policy configuration on monitored nodes
 - Configure IMA policy on monitored nodes