### PR TITLE
Generate runtime policies for each monitored node

### DIFF
--- a/delete_agents.yml
+++ b/delete_agents.yml
@@ -1,0 +1,9 @@
+---
+- name: Delete enrolled Agents from the Verifier
+  hosts: controller
+  gather_facts: true
+  tasks:
+    - name: Delete agents that were enrolled with the Verifier
+      include_role:
+        name: delete_agents
+

--- a/demo.yml
+++ b/demo.yml
@@ -116,3 +116,19 @@
     - name: Generate policies for each monitored node
       include_role:
         name: generate_policy
+
+    - name: Open ports on firewall
+      ansible.posix.firewalld:
+        port: "{{ item }}"
+        permanent: true
+        immediate: true
+        state: enabled
+      with_items:
+        - "9002/tcp"
+        - "8992/tcp"
+
+    - name: Start Keylime agent
+      become: true
+      ansible.builtin.systemd_service:
+        state: started
+        name: keylime_agent

--- a/demo.yml
+++ b/demo.yml
@@ -43,12 +43,14 @@
       include_role:
         name: create_vms
 
-    - name: Pull verifier and registrar images
+    - name: Pull verifier, registrar, and tenant images
       vars:
         container_images:
           - name: "keylime/keylime_verifier"
             tag: "master"
           - name: "keylime/keylime_registrar"
+            tag: "master"
+          - name: "keylime/keylime_tenant"
             tag: "master"
       include_role:
         name: pull_image
@@ -78,6 +80,10 @@
           - "{{ demo_dir }}/certs:/var/lib/keylime:z"
         env:
           KEYLIME_REGISTRAR_IP: "0.0.0.0"
+
+    - name: Copy TPM certificates to be usable by Keylime tenant
+      include_role:
+        name: tpm_certs
 
     - name: Start the VMs for the monitored nodes
       include_role:

--- a/demo.yml
+++ b/demo.yml
@@ -112,3 +112,7 @@
         ima_cert_dir: "/root/ima/certs"
       include_role:
         name: ima_setup
+
+    - name: Generate policies for each monitored node
+      include_role:
+        name: generate_policy

--- a/enroll.yml
+++ b/enroll.yml
@@ -1,0 +1,36 @@
+---
+- name: Enroll monitored nodes
+  hosts: controller
+  gather_facts: true
+  tasks:
+    - name: Get list of registered Agents from Registrar
+      vars:
+        certs_dir: "{{ demo_dir }}/certs"
+        ip: "{{ hostvars['controller']['ansible_default_ipv4']['address'] }}"
+      ansible.builtin.shell:
+        podman run --rm -ti -v {{ demo_dir }}/certs:/var/lib/keylime:z --network host -e KEYLIME_TENANT_REGISTRAR_IP={{ ip }} quay.io/keylime/keylime_tenant:master -c reglist
+      register: registered_agents
+
+    - name: Check if monitored nodes are registered
+      vars:
+        registered: "{{ registered_agents.stdout_lines[-1] | from_json | json_query('uuids') }}"
+        uuid: "{{ item | to_uuid }}"
+      fail:
+        msg: "{{ item }} with uuid {{ uuid }} was not registered"
+      when: not(uuid in registered)
+      with_items: "{{ groups['monitored'] }}"
+
+    - name: Delete agents that were enrolled before with the Verifier
+      include_role:
+        name: delete_agents
+
+    - name: Enroll each monitored node using their specific policy
+      vars:
+        certs_dir: "{{ demo_dir }}/certs"
+        local_ip: "{{ hostvars['controller']['ansible_default_ipv4']['address'] }}"
+        uuid: "{{ item | to_uuid }}"
+        policy: "{{ item }}.policy"
+      ansible.builtin.shell:
+        podman run --rm -ti -v {{ demo_dir }}/certs:/var/lib/keylime:z -v {{ demo_dir }}/policies:/var/lib/keylime/policies:z --network host -e KEYLIME_TENANT_REGISTRAR_IP={{ local_ip }} -e KEYLIME_TENANT_VERIFIER_IP={{ local_ip }} quay.io/keylime/keylime_tenant:master -c add -u {{ uuid }} --runtime-policy /var/lib/keylime/policies/{{ policy }}
+      with_items: "{{ groups['monitored'] }}"
+

--- a/roles/configure_network/tasks/main.yml
+++ b/roles/configure_network/tasks/main.yml
@@ -60,7 +60,19 @@
   become: true
   ansible.posix.firewalld:
     rich_rule: rule family=ipv4 source address="{{network.dhcp_subnet}}/24" accept
-    zone: libvirt
+    zone: libvirt-routed
     permanent: false
     immediate: true
     state: enabled
+
+- name: Change libvirt-to-host policy temporarily to allow requests from VMs to host
+  become: true
+  ansible.builtin.command: firewall-cmd --policy=libvirt-to-host --add-rich-rule='rule family=ipv4 source address="{{network.dhcp_subnet}}/24" accept'
+
+- name: Enable ip forward temporarily
+  become: true
+  ansible.builtin.command: sysctl -w net.ipv4.ip_forward=1
+
+- name: Add route to redirect to packages from the host to virtual network
+  become: true
+  ansible.builtin.command: ip route replace 192.168.42.0/24 via 192.168.42.1 dev virbr-demo

--- a/roles/configure_network/tasks/main.yml
+++ b/roles/configure_network/tasks/main.yml
@@ -43,15 +43,6 @@
     insertafter: EOF
     backup: yes
 
-- name: Create directory if not present
-  become: true
-  ansible.builtin.file:
-    path: "/etc/systemd/resolved.conf.d"
-    state: directory
-    owner: root
-    group: root
-    mode: "0644"
-
 - name: Configure controller systemd-resolved for hostname resolution (DNS)
   become: true
   ansible.builtin.shell:

--- a/roles/configure_network/templates/demo-network.xml.j2
+++ b/roles/configure_network/templates/demo-network.xml.j2
@@ -1,7 +1,7 @@
 <network>
   <name>{{ network.name }}</name>
   <uuid>{{ network.uuid }}</uuid>
-  <forward mode="nat"/>
+  <forward mode="route"/>
   <bridge name="{{ network.bridge }}" stp="on" delay="0"/>
   <mac address="52:54:00:ab:cd:ef"/>
   <domain name="{{ network.domain }}" localOnly="yes"/>

--- a/roles/create_vms/tasks/main.yml
+++ b/roles/create_vms/tasks/main.yml
@@ -28,23 +28,33 @@
     name: configure_network
 
 - name: Download latest Fedora stable image
+  vars:
+    missing: "{{ groups['monitored'] | reject('in', all_vms.list_vms) | list }}"
   include_role:
     name: download_fedora_image
+  when: missing | length > 0
 
 - name: Fail if the Fedora releases info is not available
+  vars:
+    missing: "{{ groups['monitored'] | reject('in', all_vms.list_vms) | list }}"
   fail: msg="The Fedora releases information is not available"
-  when: latest_fedora_release is undefined
+  when: (missing | length > 0) and (latest_fedora_release is undefined)
 
 - name: Check if the latest Fedora release image was already downloaded
+  vars:
+    missing: "{{ groups['monitored'] | reject('in', all_vms.list_vms) | list }}"
   ansible.builtin.stat:
     path: "{{ demo_dir }}/{{ fedora_filename }}"
   run_once: true
   register: image_downloaded
   failed_when: fedora_filename is undefined
+  when: missing | length > 0
 
 - name: Fail if the image is not available
+  vars:
+    missing: "{{ groups['monitored'] | reject('in', all_vms.list_vms) | list }}"
   fail: msg="The Fedora image is not available"
-  when: not(image_downloaded.stat.exists)
+  when: (missing | length > 0) and not(image_downloaded.stat.exists)
 
 - name: Create SSH keys if not created yet
   include_role:

--- a/roles/delete_agents/tasks/main.yml
+++ b/roles/delete_agents/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Get the Agent list from the Verifier
+  vars:
+    certs_dir: "{{ demo_dir }}/certs"
+    ip: "{{ hostvars['controller']['ansible_default_ipv4']['address'] }}"
+    uuid: "{{ item | to_uuid }}"
+  ansible.builtin.shell:
+    podman run --rm -ti -v {{ demo_dir }}/certs:/var/lib/keylime:z --network host -e KEYLIME_TENANT_VERIFIER_IP={{ ip }} quay.io/keylime/keylime_tenant:master -c cvlist
+  register: verifier_agents
+
+- name: Delete agents that were enrolled before with the Verifier
+  vars:
+    certs_dir: "{{ demo_dir }}/certs"
+    local_ip: "{{ hostvars['controller']['ansible_default_ipv4']['address'] }}"
+  ansible.builtin.shell:
+    podman run --rm -ti -v {{ demo_dir }}/certs:/var/lib/keylime:z -v {{ demo_dir }}/policies:/var/lib/keylime/policies:z --network host -e KEYLIME_TENANT_REGISTRAR_IP={{ local_ip }} -e KEYLIME_TENANT_VERIFIER_IP={{ local_ip }} quay.io/keylime/keylime_tenant:master -c delete -u {{ item }}
+  with_items: "{{ verifier_agents.stdout_lines[-1] | from_json | json_query('uuids') | flatten }}"
+
+

--- a/roles/generate_certs/tasks/main.yml
+++ b/roles/generate_certs/tasks/main.yml
@@ -8,10 +8,11 @@
     - "{{ root_ca_dir }}"
     - "{{ ima_dir }}"
 
-- name: Generate Root CA private key
+- name: Generate Root CA private key if not present
   community.crypto.openssl_privatekey:
     path: "{{ root_ca_dir }}/private.key"
     size: 4096
+  register: generate_root_ca_key
 
 - name: Generate Root CA CSR
   community.crypto.openssl_csr_pipe:
@@ -29,6 +30,7 @@
     basic_constraints_critical: true
     key_usage_critical: true
   register: root_csr
+  when: generate_root_ca_key.changed
 
 - name: Self-sign Root CA certificate
   community.crypto.x509_certificate:
@@ -37,11 +39,13 @@
     privatekey_path: "{{ root_ca_dir }}/private.key"
     provider: selfsigned
     selfsigned_create_subject_key_identifier: "create_if_not_provided"
+  when: root_csr.changed
 
 - name: Generate IMA CA private key
   community.crypto.openssl_privatekey:
     path: "{{ ima_dir }}/ca.key"
     size: 4096
+  register: generate_ima_ca_key
 
 - name: Generate IMA CA CSR
   community.crypto.openssl_csr_pipe:
@@ -56,6 +60,7 @@
       - "keyCertSign"
     basic_constraints_critical: true
     key_usage_critical: true
+  when: generate_ima_ca_key.changed
   register: ima_ca_csr
 
 - name: Self-sign IMA CA certificate
@@ -65,11 +70,13 @@
     privatekey_path: "{{ ima_dir }}/ca.key"
     provider: selfsigned
     selfsigned_create_subject_key_identifier: "create_if_not_provided"
+  when: ima_ca_csr.changed
 
 - name: Generate IMA signing key
   community.crypto.openssl_privatekey:
     path: "{{ ima_dir }}/private.key"
     size: 3072
+  register: generate_ima_key
 
 - name: Generate IMA signing key CSR
   community.crypto.openssl_csr:
@@ -88,6 +95,8 @@
       - "nonRepudiation"
     basic_constraints_critical: true
     key_usage_critical: true
+  when: generate_ima_key.changed
+  register: ima_csr
 
 - name: Sign IMA signing key certificate with IMA CA
   community.crypto.x509_certificate:
@@ -98,3 +107,4 @@
     ownca_path: "{{ ima_dir }}/ca.crt"
     ownca_create_authority_key_identifier: true
     ownca_create_subject_key_identifier: "create_if_not_provided"
+  when: ima_csr.changed

--- a/roles/generate_policy/tasks/main.yml
+++ b/roles/generate_policy/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Install keylime-policy tool
+  ansible.builtin.dnf:
+    name: "python3-keylime"
+    state: present
+
+- name: Generate runtime policy using current IMA log
+  ansible.builtin.shell:
+    keylime-policy create runtime --ima-measurement --rootfs '/' --ramdisk-dir '/boot/'
+  register: keylime_policy
+
+- name: Create policies directory if not present
+  ansible.builtin.file:
+    path: "{{ demo_dir }}/policies"
+    state: directory
+    mode: '0755'
+  delegate_to: controller
+
+- name: Write policy to the controller
+  ansible.builtin.copy:
+    content: "{{ keylime_policy.stdout }}"
+    dest: "{{ demo_dir }}/policies/{{ ansible_hostname }}.policy"
+  delegate_to: controller

--- a/roles/tpm_certs/tasks/main.yml
+++ b/roles/tpm_certs/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Create TPM cert store directory if not present
+  ansible.builtin.file:
+    path: "{{ demo_dir }}/certs/tpm_cert_store"
+    state: directory
+    mode: '0755'
+
+- name: Copy swtpm EK certificate issuer certificate
+  ansible.builtin.copy:
+    src: "~/.config/var/lib/swtpm-localca/issuercert.pem"
+    dest: "{{ demo_dir }}/certs/tpm_cert_store/issuercert.pem"
+    mode: '0644'
+
+- name: Copy swtpm EK certificate root CA certificate
+  ansible.builtin.copy:
+    src: "~/.config/var/lib/swtpm-localca/swtpm-localca-rootca-cert.pem"
+    dest: "{{ demo_dir }}/certs/tpm_cert_store/swtpm-localca-rootca-cert.pem"
+    mode: '0644'
+


### PR DESCRIPTION
- Add playbooks to enroll and delete Agents from the Verifier.
- Change the virtual network configuration forwarding mode from NAT to routed
- Pull the Keylime tenant container
- Copy the `swtpm` CA certificates  to a location where the tenant can use them
- Only try to download a Fedora image if the VMs are missing